### PR TITLE
Feature/small setup py changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+ENV/
 build/
 develop-eggs/
 dist/
@@ -70,4 +71,4 @@ tests/layouter/output/
 tests/csv_export/output/
 tests/xml_import_export/output/
 tests/csv_import/output/
-
+**/*.sw[po]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.19] - 2019-01-05
+### Added
+  - basic changelog with release dates
+### Changed
+  - setup.py entries to make description in pypi more readable
+  - setup.py install requires now reads needed modules from requirements.txt
+
+## [0.0.18] - 2017-07-14
+## [0.0.17] - 2017-07-14
+## [0.0.16] - 2017-07-13
+## [0.0.15] - 2017-07-07
+## [0.0.14] - 2017-06-28
+## [0.0.12] - 2017-06-23
+## [0.0.11] - 2017-03-28
+## [0.0.10] - 2017-03-28
+## [0.0.9] - 2017-03-28
+## [0.0.8] - 2017-03-28
+## [0.0.7] - 2017-03-28
+## [0.0.6] - 2017-03-28
+## [0.0.5] - 2017-03-28
+## [0.0.4] - 2017-03-28
+## [0.0.3] - 2017-02-20
+## [0.0.2] - 2016-09-18
+## [0.0.1] - 2016-09-08

--- a/setup.py
+++ b/setup.py
@@ -25,12 +25,18 @@ setup(
     url="https://github.com/KrzyHonk/bpmn-python",
     download_url="https://github.com/KrzyHonk/bpmn-python/tarball/0.0.19-SNAPSHOT",
     packages=find_packages(exclude=['docs', 'tests*']),
-    install_requires=[
-        'networkx',
-        'matplotlib',
-        'pydotplus',
-        'six',
-        'pandas',
-    ],
-    long_description=read('README.md'),
+    install_requires=read('requirements.txt').split('\n'),
+    long_description="%s\n%s" % (
+        read('README.md'),
+        read('CHANGELOG.md')
+    ),
+    long_description_content_type='text/markdown',
+    classifiers=[
+        "License :: OSI Approved :: GNU General Public License (GPL)",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
+        "Topic :: Scientific/Engineering :: Information Analysis",
+        "Topic :: Text Processing :: Markup :: XML"
+    ]
 )


### PR DESCRIPTION
Hi! 
This PR provides small but maybe useful changes - in compliance to Krzysztofs Kluza request.

Changes:
  - install_requires in setup.py are red from requirements.txt, this way there is no need to keep two lists,
  - long_description_content_type in setup.py for readability sake in pypi description page (right now it renders unformatted I guess?)
  - it might be a good idea to keep the change log so I included one :)
  - added some classifiers to make it index via pypi and google robots a little bit easier
  - git ignore vim and virtualenv files