### PR TITLE
Fix edges direction on png visualization of the bpmn graph. 

### DIFF
--- a/bpmn_python/bpmn_diagram_visualizer.py
+++ b/bpmn_python/bpmn_diagram_visualizer.py
@@ -88,7 +88,7 @@ def bpmn_diagram_to_png(bpmn_diagram, file_name):
         graph.add_node(n)
 
     for edge in g.edges(data=True):
-        e = pydotplus.Edge(src=edge[0], dst=edge[1], label=edge[2].get(consts.Consts.name))
+        e = pydotplus.Edge(src=edge[2].get(consts.Consts.source_ref), dst=edge[2].get(consts.Consts.target_ref), label=edge[2].get(consts.Consts.name))
         graph.add_edge(e)
 
     graph.write(file_name + ".png", format='png')


### PR DESCRIPTION
I found (and solve in the PR) an issue with converting bpmn graph to png - direction of edges weren't based on` incomming` and `outcomming`  ids (described in node's details), but based on order of adding nodes. 

Example:
 ```
import bpmn_python.bpmn_diagram_visualizer as visualizer
import bpmn_python.bpmn_diagram_rep as diagram
import graphviz

if __name__ == "__main__":
    bpmn_graph = diagram.BpmnDiagramGraph()
    bpmn_graph.create_new_diagram_graph(diagram_name="diagram1")
    process_id = bpmn_graph.add_process_to_diagram()
    [start_id, _] = bpmn_graph.add_start_event_to_diagram(process_id, start_event_name="start_event",
                                                          start_event_definition="timer")
    [task1_id, _] = bpmn_graph.add_task_to_diagram(process_id, task_name="task1")
    bpmn_graph.add_sequence_flow_to_diagram(process_id, start_id, task1_id, "start_to_one")
    [task2_id, _] = bpmn_graph.add_task_to_diagram(process_id, task_name="task2")
    [flow_id, _] = bpmn_graph.add_sequence_flow_to_diagram(process_id,
                                                           source_ref_id=task2_id,
                                                           target_ref_id=task1_id,
                                                           sequence_flow_name="two_to_one")

    visualizer.bpmn_diagram_to_png(bpmn_graph, "./../test_png/graph_incorrect")
```
Result of the code above: 
![graph_incorrect](https://user-images.githubusercontent.com/34707786/79596947-b1f76980-80e1-11ea-8fef-cefb2785ed30.png)


with corrected function `bpmn_diagram_to_png()` result of the same code looks: 
![graph_correct](https://user-images.githubusercontent.com/34707786/79596839-8d02f680-80e1-11ea-8a9f-49569c50a6e9.png)


I hope the change will help others student like me to use the package in their project of developing process mining for bussiness processes.

Best regards,  