### PR TITLE
Update library for Python 3.13 compatibility and modern dependencies

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,14 @@ tox = "*"
 
 [packages]
 bpmn-python = {editable = true,path = "."}
+six = "*"
+pandas = "*"
+networkx = "*"
+matplotlib = "*"
+pydotplus = "*"
+pydot = "*"
+pytest = "*"
+tox = "*"
 
 [requires]
-python_version = "3.7"
+python_version = "3.13"

--- a/bpmn_python/bpmn_diagram_import.py
+++ b/bpmn_python/bpmn_diagram_import.py
@@ -106,8 +106,8 @@ class BpmnDiagramGraphImport(object):
         process_ref = participant_element.getAttribute(consts.Consts.process_ref)
         if participant_element.getAttribute(consts.Consts.process_ref) == '':
             diagram_graph.add_node(participant_id)
-            diagram_graph.node[participant_id][consts.Consts.type] = consts.Consts.participant
-            diagram_graph.node[participant_id][consts.Consts.process] = participant_id
+            diagram_graph.nodes[participant_id][consts.Consts.type] = consts.Consts.participant
+            diagram_graph.nodes[participant_id][consts.Consts.process] = participant_id
         participants_dictionary[participant_id] = {consts.Consts.name: name, consts.Consts.process_ref: process_ref}
 
     @staticmethod
@@ -347,14 +347,14 @@ class BpmnDiagramGraphImport(object):
         """
         element_id = flow_node_element.getAttribute(consts.Consts.id)
         bpmn_graph.add_node(element_id)
-        bpmn_graph.node[element_id][consts.Consts.id] = element_id
-        bpmn_graph.node[element_id][consts.Consts.type] = \
+        bpmn_graph.nodes[element_id][consts.Consts.id] = element_id
+        bpmn_graph.nodes[element_id][consts.Consts.type] = \
             utils.BpmnImportUtils.remove_namespace_from_tag_name(flow_node_element.tagName)
-        bpmn_graph.node[element_id][consts.Consts.node_name] = \
+        bpmn_graph.nodes[element_id][consts.Consts.node_name] = \
             flow_node_element.getAttribute(consts.Consts.name) \
                 if flow_node_element.hasAttribute(consts.Consts.name) \
                 else ""
-        bpmn_graph.node[element_id][consts.Consts.process] = process_id
+        bpmn_graph.nodes[element_id][consts.Consts.process] = process_id
         process_attributes[consts.Consts.node_ids].append(element_id)
 
         # add incoming flow node list
@@ -365,7 +365,7 @@ class BpmnDiagramGraphImport(object):
                 if tag_name == consts.Consts.incoming_flow:
                     incoming_value = tmp_element.firstChild.nodeValue
                     incoming_list.append(incoming_value)
-        bpmn_graph.node[element_id][consts.Consts.incoming_flow] = incoming_list
+        bpmn_graph.nodes[element_id][consts.Consts.incoming_flow] = incoming_list
 
         # add outgoing flow node list
         outgoing_list = []
@@ -375,7 +375,7 @@ class BpmnDiagramGraphImport(object):
                 if tag_name == consts.Consts.outgoing_flow:
                     outgoing_value = tmp_element.firstChild.nodeValue
                     outgoing_list.append(outgoing_value)
-        bpmn_graph.node[element_id][consts.Consts.outgoing_flow] = outgoing_list
+        bpmn_graph.nodes[element_id][consts.Consts.outgoing_flow] = outgoing_list
 
     @staticmethod
     def import_task_to_graph(diagram_graph, process_id, process_attributes, task_element):
@@ -410,11 +410,11 @@ class BpmnDiagramGraphImport(object):
                                                         subprocess_element)
 
         subprocess_id = subprocess_element.getAttribute(consts.Consts.id)
-        diagram_graph.node[subprocess_id][consts.Consts.triggered_by_event] = \
+        diagram_graph.nodes[subprocess_id][consts.Consts.triggered_by_event] = \
             subprocess_element.getAttribute(consts.Consts.triggered_by_event) \
                 if subprocess_element.hasAttribute(consts.Consts.triggered_by_event) else "false"
 
-        subprocess_attributes = diagram_graph.node[subprocess_id]
+        subprocess_attributes = diagram_graph.nodes[subprocess_id]
         subprocess_attributes[consts.Consts.node_ids] = []
         for element in utils.BpmnImportUtils.iterate_elements(subprocess_element):
             if element.nodeType != element.TEXT_NODE:
@@ -444,7 +444,7 @@ class BpmnDiagramGraphImport(object):
         BpmnDiagramGraphImport.import_flow_node_to_graph(diagram_graph, process_id, process_attributes,
                                                          data_object_element)
         data_object_id = data_object_element.getAttribute(consts.Consts.id)
-        diagram_graph.node[data_object_id][consts.Consts.is_collection] = \
+        diagram_graph.nodes[data_object_id][consts.Consts.is_collection] = \
             data_object_element.getAttribute(consts.Consts.is_collection) \
                 if data_object_element.hasAttribute(consts.Consts.is_collection) else "false"
 
@@ -464,7 +464,7 @@ class BpmnDiagramGraphImport(object):
         BpmnDiagramGraphImport.import_flow_node_to_graph(diagram_graph, process_id, process_attributes, element)
 
         element_id = element.getAttribute(consts.Consts.id)
-        diagram_graph.node[element_id][consts.Consts.default] = element.getAttribute(consts.Consts.default) \
+        diagram_graph.nodes[element_id][consts.Consts.default] = element.getAttribute(consts.Consts.default) \
             if element.hasAttribute(consts.Consts.default) else None
 
     @staticmethod
@@ -482,7 +482,7 @@ class BpmnDiagramGraphImport(object):
         """
         element_id = element.getAttribute(consts.Consts.id)
         BpmnDiagramGraphImport.import_flow_node_to_graph(diagram_graph, process_id, process_attributes, element)
-        diagram_graph.node[element_id][consts.Consts.gateway_direction] = \
+        diagram_graph.nodes[element_id][consts.Consts.gateway_direction] = \
             element.getAttribute(consts.Consts.gateway_direction) \
                 if element.hasAttribute(consts.Consts.gateway_direction) else "Unspecified"
 
@@ -501,7 +501,7 @@ class BpmnDiagramGraphImport(object):
         """
         element_id = element.getAttribute(consts.Consts.id)
         BpmnDiagramGraphImport.import_gateway_to_graph(diagram_graph, process_id, process_attributes, element)
-        diagram_graph.node[element_id][consts.Consts.default] = element.getAttribute(consts.Consts.default) \
+        diagram_graph.nodes[element_id][consts.Consts.default] = element.getAttribute(consts.Consts.default) \
             if element.hasAttribute(consts.Consts.default) else None
         # TODO sequence of conditions
         # Can't get any working example of Complex gateway, so I'm not sure how exactly those conditions are kept
@@ -522,9 +522,9 @@ class BpmnDiagramGraphImport(object):
         """
         element_id = element.getAttribute(consts.Consts.id)
         BpmnDiagramGraphImport.import_gateway_to_graph(diagram_graph, process_id, process_attributes, element)
-        diagram_graph.node[element_id][consts.Consts.instantiate] = element.getAttribute(consts.Consts.instantiate) \
+        diagram_graph.nodes[element_id][consts.Consts.instantiate] = element.getAttribute(consts.Consts.instantiate) \
             if element.hasAttribute(consts.Consts.instantiate) else "false"
-        diagram_graph.node[element_id][consts.Consts.event_gateway_type] = \
+        diagram_graph.nodes[element_id][consts.Consts.event_gateway_type] = \
             element.getAttribute(consts.Consts.event_gateway_type) \
                 if element.hasAttribute(consts.Consts.event_gateway_type) else "Exclusive"
 
@@ -543,7 +543,7 @@ class BpmnDiagramGraphImport(object):
         """
         element_id = element.getAttribute(consts.Consts.id)
         BpmnDiagramGraphImport.import_gateway_to_graph(diagram_graph, process_id, process_attributes, element)
-        diagram_graph.node[element_id][consts.Consts.default] = element.getAttribute(consts.Consts.default) \
+        diagram_graph.nodes[element_id][consts.Consts.default] = element.getAttribute(consts.Consts.default) \
             if element.hasAttribute(consts.Consts.default) else None
 
     @staticmethod
@@ -578,7 +578,7 @@ class BpmnDiagramGraphImport(object):
                 event_def_tmp = {consts.Consts.id: event_def_xml[index].getAttribute(consts.Consts.id),
                                  consts.Consts.definition_type: definition_type}
                 event_def_list.append(event_def_tmp)
-        diagram_graph.node[element_id][consts.Consts.event_definitions] = event_def_list
+        diagram_graph.nodes[element_id][consts.Consts.event_definitions] = event_def_list
 
     @staticmethod
     def import_start_event_to_graph(diagram_graph, process_id, process_attributes, element):
@@ -599,10 +599,10 @@ class BpmnDiagramGraphImport(object):
         start_event_definitions = {'messageEventDefinition', 'timerEventDefinition', 'conditionalEventDefinition',
                                    'escalationEventDefinition', 'signalEventDefinition'}
         BpmnDiagramGraphImport.import_flow_node_to_graph(diagram_graph, process_id, process_attributes, element)
-        diagram_graph.node[element_id][consts.Consts.parallel_multiple] = \
+        diagram_graph.nodes[element_id][consts.Consts.parallel_multiple] = \
             element.getAttribute(consts.Consts.parallel_multiple) \
                 if element.hasAttribute(consts.Consts.parallel_multiple) else "false"
-        diagram_graph.node[element_id][consts.Consts.is_interrupting] = \
+        diagram_graph.nodes[element_id][consts.Consts.is_interrupting] = \
             element.getAttribute(consts.Consts.is_interrupting) \
                 if element.hasAttribute(consts.Consts.is_interrupting) else "true"
         BpmnDiagramGraphImport.import_event_definition_elements(diagram_graph, element, start_event_definitions)
@@ -627,7 +627,7 @@ class BpmnDiagramGraphImport(object):
                                                 'signalEventDefinition', 'conditionalEventDefinition',
                                                 'escalationEventDefinition'}
         BpmnDiagramGraphImport.import_flow_node_to_graph(diagram_graph, process_id, process_attributes, element)
-        diagram_graph.node[element_id][consts.Consts.parallel_multiple] = \
+        diagram_graph.nodes[element_id][consts.Consts.parallel_multiple] = \
             element.getAttribute(consts.Consts.parallel_multiple) \
                 if element.hasAttribute(consts.Consts.parallel_multiple) else "false"
         BpmnDiagramGraphImport.import_event_definition_elements(diagram_graph, element,
@@ -691,13 +691,13 @@ class BpmnDiagramGraphImport(object):
                                       'conditionalEventDefinition', 'escalationEventDefinition', 'errorEventDefinition'}
         BpmnDiagramGraphImport.import_flow_node_to_graph(diagram_graph, process_id, process_attributes, element)
 
-        diagram_graph.node[element_id][consts.Consts.parallel_multiple] = \
+        diagram_graph.nodes[element_id][consts.Consts.parallel_multiple] = \
             element.getAttribute(consts.Consts.parallel_multiple) \
                 if element.hasAttribute(consts.Consts.parallel_multiple) else "false"
-        diagram_graph.node[element_id][consts.Consts.cancel_activity] = \
+        diagram_graph.nodes[element_id][consts.Consts.cancel_activity] = \
             element.getAttribute(consts.Consts.cancel_activity) \
                 if element.hasAttribute(consts.Consts.cancel_activity) else "true"
-        diagram_graph.node[element_id][consts.Consts.attached_to_ref] = \
+        diagram_graph.nodes[element_id][consts.Consts.attached_to_ref] = \
             element.getAttribute(consts.Consts.attached_to_ref)
 
         BpmnDiagramGraphImport.import_event_definition_elements(diagram_graph, element,
@@ -749,15 +749,15 @@ class BpmnDiagramGraphImport(object):
         added when processing nodes, but listing incoming / outgoing nodes under node element is optional - this way
         we can make sure this info will be imported.
         '''
-        if consts.Consts.outgoing_flow not in diagram_graph.node[source_ref]:
-            diagram_graph.node[source_ref][consts.Consts.outgoing_flow] = []
-        outgoing_list = diagram_graph.node[source_ref][consts.Consts.outgoing_flow]
+        if consts.Consts.outgoing_flow not in diagram_graph.nodes[source_ref]:
+            diagram_graph.nodes[source_ref][consts.Consts.outgoing_flow] = []
+        outgoing_list = diagram_graph.nodes[source_ref][consts.Consts.outgoing_flow]
         if flow_id not in outgoing_list:
             outgoing_list.append(flow_id)
 
-        if consts.Consts.incoming_flow not in diagram_graph.node[target_ref]:
-            diagram_graph.node[target_ref][consts.Consts.incoming_flow] = []
-        incoming_list = diagram_graph.node[target_ref][consts.Consts.incoming_flow]
+        if consts.Consts.incoming_flow not in diagram_graph.nodes[target_ref]:
+            diagram_graph.nodes[target_ref][consts.Consts.incoming_flow] = []
+        incoming_list = diagram_graph.nodes[target_ref][consts.Consts.incoming_flow]
         if flow_id not in incoming_list:
             incoming_list.append(flow_id)
 
@@ -797,15 +797,15 @@ class BpmnDiagramGraphImport(object):
         added when processing nodes, but listing incoming / outgoing nodes under node element is optional - this way
         we can make sure this info will be imported.
         '''
-        if consts.Consts.outgoing_flow not in diagram_graph.node[source_ref]:
-            diagram_graph.node[source_ref][consts.Consts.outgoing_flow] = []
-        outgoing_list = diagram_graph.node[source_ref][consts.Consts.outgoing_flow]
+        if consts.Consts.outgoing_flow not in diagram_graph.nodes[source_ref]:
+            diagram_graph.nodes[source_ref][consts.Consts.outgoing_flow] = []
+        outgoing_list = diagram_graph.nodes[source_ref][consts.Consts.outgoing_flow]
         if flow_id not in outgoing_list:
             outgoing_list.append(flow_id)
 
-        if consts.Consts.incoming_flow not in diagram_graph.node[target_ref]:
-            diagram_graph.node[target_ref][consts.Consts.incoming_flow] = []
-        incoming_list = diagram_graph.node[target_ref][consts.Consts.incoming_flow]
+        if consts.Consts.incoming_flow not in diagram_graph.nodes[target_ref]:
+            diagram_graph.nodes[target_ref][consts.Consts.incoming_flow] = []
+        incoming_list = diagram_graph.nodes[target_ref][consts.Consts.incoming_flow]
         if flow_id not in incoming_list:
             incoming_list.append(flow_id)
 
@@ -828,7 +828,7 @@ class BpmnDiagramGraphImport(object):
         element_id = shape_element.getAttribute(consts.Consts.bpmn_element)
         bounds = shape_element.getElementsByTagNameNS("*", "Bounds")[0]
         if diagram_graph.has_node(element_id):
-            node = diagram_graph.node[element_id]
+            node = diagram_graph.nodes[element_id]
             node[consts.Consts.width] = bounds.getAttribute(consts.Consts.width)
             node[consts.Consts.height] = bounds.getAttribute(consts.Consts.height)
 

--- a/bpmn_python/bpmn_diagram_layouter.py
+++ b/bpmn_python/bpmn_diagram_layouter.py
@@ -369,7 +369,7 @@ def insert_into_grid(grid, row, col, node_id):
     if occupied_cell:
         for grid_cell in grid:
             if grid_cell.row >= row:
-                grid_cell.row += consts.Consts.width
+                grid_cell.row += consts.Consts.grid_column_width
     grid.append(cell_class.GridCell(row, col, node_id))
 
 

--- a/bpmn_python/bpmn_diagram_rep.py
+++ b/bpmn_python/bpmn_diagram_rep.py
@@ -256,19 +256,19 @@ class BpmnDiagramGraph(object):
         if node_id is None:
             node_id = BpmnDiagramGraph.id_prefix + str(uuid.uuid4())
         self.diagram_graph.add_node(node_id)
-        self.diagram_graph.node[node_id][consts.Consts.id] = node_id
-        self.diagram_graph.node[node_id][consts.Consts.type] = node_type
-        self.diagram_graph.node[node_id][consts.Consts.node_name] = name
-        self.diagram_graph.node[node_id][consts.Consts.incoming_flow] = []
-        self.diagram_graph.node[node_id][consts.Consts.outgoing_flow] = []
-        self.diagram_graph.node[node_id][consts.Consts.process] = process_id
+        self.diagram_graph.nodes[node_id][consts.Consts.id] = node_id
+        self.diagram_graph.nodes[node_id][consts.Consts.type] = node_type
+        self.diagram_graph.nodes[node_id][consts.Consts.node_name] = name
+        self.diagram_graph.nodes[node_id][consts.Consts.incoming_flow] = []
+        self.diagram_graph.nodes[node_id][consts.Consts.outgoing_flow] = []
+        self.diagram_graph.nodes[node_id][consts.Consts.process] = process_id
 
         # Adding some dummy constant values
-        self.diagram_graph.node[node_id][consts.Consts.width] = "100"
-        self.diagram_graph.node[node_id][consts.Consts.height] = "100"
-        self.diagram_graph.node[node_id][consts.Consts.x] = "100"
-        self.diagram_graph.node[node_id][consts.Consts.y] = "100"
-        return node_id, self.diagram_graph.node[node_id]
+        self.diagram_graph.nodes[node_id][consts.Consts.width] = "100"
+        self.diagram_graph.nodes[node_id][consts.Consts.height] = "100"
+        self.diagram_graph.nodes[node_id][consts.Consts.x] = "100"
+        self.diagram_graph.nodes[node_id][consts.Consts.y] = "100"
+        return node_id, self.diagram_graph.nodes[node_id]
 
     def add_task_to_diagram(self, process_id, task_name="", node_id=None):
         """
@@ -304,8 +304,8 @@ class BpmnDiagramGraph(object):
         """
         subprocess_id, subprocess = self.add_flow_node_to_diagram(process_id, consts.Consts.subprocess, subprocess_name,
                                                                   node_id)
-        self.diagram_graph.node[subprocess_id][consts.Consts.is_expanded] = "true" if is_expanded else "false"
-        self.diagram_graph.node[subprocess_id][consts.Consts.triggered_by_event] = \
+        self.diagram_graph.nodes[subprocess_id][consts.Consts.is_expanded] = "true" if is_expanded else "false"
+        self.diagram_graph.nodes[subprocess_id][consts.Consts.triggered_by_event] = \
             "true" if triggered_by_event else "false"
         return subprocess_id, subprocess
 
@@ -337,9 +337,9 @@ class BpmnDiagramGraph(object):
         """
         start_event_id, start_event = self.add_flow_node_to_diagram(process_id, consts.Consts.start_event,
                                                                     start_event_name, node_id)
-        self.diagram_graph.node[start_event_id][consts.Consts.parallel_multiple] = \
+        self.diagram_graph.nodes[start_event_id][consts.Consts.parallel_multiple] = \
             "true" if parallel_multiple else "false"
-        self.diagram_graph.node[start_event_id][consts.Consts.is_interrupting] = "true" if is_interrupting else "false"
+        self.diagram_graph.nodes[start_event_id][consts.Consts.is_interrupting] = "true" if is_interrupting else "false"
         start_event_definitions = {"message": "messageEventDefinition", "timer": "timerEventDefinition",
                                    "conditional": "conditionalEventDefinition", "signal": "signalEventDefinition",
                                    "escalation": "escalationEventDefinition"}
@@ -355,7 +355,7 @@ class BpmnDiagramGraph(object):
         elif start_event_definition == "escalation":
             event_def_list.append(BpmnDiagramGraph.add_event_definition_element("escalation", start_event_definitions))
 
-        self.diagram_graph.node[start_event_id][consts.Consts.event_definitions] = event_def_list
+        self.diagram_graph.nodes[start_event_id][consts.Consts.event_definitions] = event_def_list
         return start_event_id, start_event
 
     def add_end_event_to_diagram(self, process_id, end_event_name="", end_event_definition=None, node_id=None):
@@ -397,7 +397,7 @@ class BpmnDiagramGraph(object):
         elif end_event_definition == "error":
             event_def_list.append(self.add_event_definition_element("error", end_event_definitions))
 
-        self.diagram_graph.node[end_event_id][consts.Consts.event_definitions] = event_def_list
+        self.diagram_graph.nodes[end_event_id][consts.Consts.event_definitions] = event_def_list
         return end_event_id, end_event
 
     @staticmethod
@@ -431,7 +431,7 @@ class BpmnDiagramGraph(object):
         if not (gateway_direction in ("Unspecified", "Converging", "Diverging", "Mixed")):
             raise bpmn_exception.BpmnPythonError("Invalid value passed as gatewayDirection parameter. Value passed: "
                                                  + gateway_direction)
-        self.diagram_graph.node[gateway_id][consts.Consts.gateway_direction] = gateway_direction
+        self.diagram_graph.nodes[gateway_id][consts.Consts.gateway_direction] = gateway_direction
         return gateway_id, gateway
 
     def add_exclusive_gateway_to_diagram(self, process_id, gateway_name="", gateway_direction="Unspecified",
@@ -453,7 +453,7 @@ class BpmnDiagramGraph(object):
                                                                               gateway_name=gateway_name,
                                                                               gateway_direction=gateway_direction,
                                                                               node_id=node_id)
-        self.diagram_graph.node[exclusive_gateway_id][consts.Consts.default] = default
+        self.diagram_graph.nodes[exclusive_gateway_id][consts.Consts.default] = default
         return exclusive_gateway_id, exclusive_gateway
 
     def add_inclusive_gateway_to_diagram(self, process_id, gateway_name="", gateway_direction="Unspecified",
@@ -475,7 +475,7 @@ class BpmnDiagramGraph(object):
                                                                               gateway_name=gateway_name,
                                                                               gateway_direction=gateway_direction,
                                                                               node_id=node_id)
-        self.diagram_graph.node[inclusive_gateway_id][consts.Consts.default] = default
+        self.diagram_graph.nodes[inclusive_gateway_id][consts.Consts.default] = default
         return inclusive_gateway_id, inclusive_gateway
 
     def add_parallel_gateway_to_diagram(self, process_id, gateway_name="", gateway_direction="Unspecified",
@@ -523,8 +523,8 @@ class BpmnDiagramGraph(object):
         flow[consts.Consts.process] = process_id
         flow[consts.Consts.source_ref] = source_ref_id
         flow[consts.Consts.target_ref] = target_ref_id
-        source_node = self.diagram_graph.node[source_ref_id]
-        target_node = self.diagram_graph.node[target_ref_id]
+        source_node = self.diagram_graph.nodes[source_ref_id]
+        target_node = self.diagram_graph.nodes[target_ref_id]
         flow[consts.Consts.waypoints] = \
             [(source_node[consts.Consts.x], source_node[consts.Consts.y]),
              (target_node[consts.Consts.x], target_node[consts.Consts.y])]

--- a/bpmn_python/bpmn_diagram_visualizer.py
+++ b/bpmn_python/bpmn_diagram_visualizer.py
@@ -64,6 +64,15 @@ def bpmn_diagram_to_dot_file(bpmn_diagram, file_name):
     :param file_name: name of generated file.
     """
     g = bpmn_diagram.diagram_graph
+
+    for node, nodeData in g.nodes(data=True):
+        for key in list(nodeData.keys()):
+            value = nodeData[key]
+            quoted_value = (
+                f'"{value}"'
+            )
+            nodeData[key] = quoted_value
+
     write_dot(g, file_name + ".dot")
 
 

--- a/bpmn_python/bpmn_process_csv_import.py
+++ b/bpmn_python/bpmn_process_csv_import.py
@@ -261,9 +261,9 @@ def add_outgoing_flow(node_id, successor_node_id, bpmn_diagram):
     :param successor_node_id:
     :param bpmn_diagram:
     """
-    if bpmn_diagram.diagram_graph.node[node_id].get(consts.Consts.outgoing_flow) is None:
-        bpmn_diagram.diagram_graph.node[node_id][consts.Consts.outgoing_flow] = []
-    bpmn_diagram.diagram_graph.node[node_id][consts.Consts.outgoing_flow].append(get_flow_id(node_id, successor_node_id))
+    if bpmn_diagram.diagram_graph.nodes[node_id].get(consts.Consts.outgoing_flow) is None:
+        bpmn_diagram.diagram_graph.nodes[node_id][consts.Consts.outgoing_flow] = []
+    bpmn_diagram.diagram_graph.nodes[node_id][consts.Consts.outgoing_flow].append(get_flow_id(node_id, successor_node_id))
 
 
 def add_incoming_flow(node_id, from_node_id, bpmn_diagram):
@@ -273,9 +273,9 @@ def add_incoming_flow(node_id, from_node_id, bpmn_diagram):
     :param from_node_id:
     :param bpmn_diagram:
     """
-    if bpmn_diagram.diagram_graph.node[node_id].get(consts.Consts.incoming_flow) is None:
-        bpmn_diagram.diagram_graph.node[node_id][consts.Consts.incoming_flow] = []
-    bpmn_diagram.diagram_graph.node[node_id][consts.Consts.incoming_flow].append(get_flow_id(from_node_id, node_id))
+    if bpmn_diagram.diagram_graph.nodes[node_id].get(consts.Consts.incoming_flow) is None:
+        bpmn_diagram.diagram_graph.nodes[node_id][consts.Consts.incoming_flow] = []
+    bpmn_diagram.diagram_graph.nodes[node_id][consts.Consts.incoming_flow].append(get_flow_id(from_node_id, node_id))
 
 
 def get_connection_condition_if_present(to_node_id, process_dict):
@@ -433,7 +433,7 @@ def get_merge_node_type(merge_successor_id, bpmn_diagram):
         prefix = result.group(1)
         split_node_id = prefix + str(prev_prev_number) + "_split"
         if bool(bpmn_diagram.diagram_graph.has_node(split_node_id)):
-            node_type = bpmn_diagram.diagram_graph.node[split_node_id][consts.Consts.type]
+            node_type = bpmn_diagram.diagram_graph.nodes[split_node_id][consts.Consts.type]
             if bool(node_type):
                 return node_type
         return consts.Consts.inclusive_gateway
@@ -466,7 +466,7 @@ def fill_graph_connections(process_dict, bpmn_diagram, sequence_flows):
     :param bpmn_diagram:
     :param sequence_flows:
     """
-    nodes_ids = list(bpmn_diagram.diagram_graph.node.keys())
+    nodes_ids = list(bpmn_diagram.diagram_graph.nodes.keys())
     nodes_ids_to_process = copy.deepcopy(nodes_ids)
     while bool(nodes_ids_to_process):
         node_id = str(nodes_ids_to_process.pop(0))
@@ -503,9 +503,9 @@ def remove_outgoing_connection(base_node, bpmn_diagram, sequence_flows):
     :param sequence_flows:
     :return:
     """
-    outgoing_flow_id = bpmn_diagram.diagram_graph.node[base_node][consts.Consts.outgoing_flow][0]
+    outgoing_flow_id = bpmn_diagram.diagram_graph.nodes[base_node][consts.Consts.outgoing_flow][0]
     neighbour_node = sequence_flows[outgoing_flow_id][consts.Consts.target_ref]
-    bpmn_diagram.diagram_graph.node[neighbour_node][consts.Consts.incoming_flow].remove(outgoing_flow_id)
+    bpmn_diagram.diagram_graph.nodes[neighbour_node][consts.Consts.incoming_flow].remove(outgoing_flow_id)
     del sequence_flows[outgoing_flow_id]
     bpmn_diagram.diagram_graph.remove_edge(base_node, neighbour_node)
     return neighbour_node
@@ -519,9 +519,9 @@ def remove_incoming_connection(base_node, bpmn_diagram, sequence_flows):
     :param sequence_flows:
     :return:
     """
-    incoming_flow_id = bpmn_diagram.diagram_graph.node[base_node][consts.Consts.incoming_flow][0]
+    incoming_flow_id = bpmn_diagram.diagram_graph.nodes[base_node][consts.Consts.incoming_flow][0]
     neighbour_node = sequence_flows[incoming_flow_id][consts.Consts.source_ref]
-    bpmn_diagram.diagram_graph.node[neighbour_node][consts.Consts.outgoing_flow].remove(incoming_flow_id)
+    bpmn_diagram.diagram_graph.nodes[neighbour_node][consts.Consts.outgoing_flow].remove(incoming_flow_id)
     del sequence_flows[incoming_flow_id]
     bpmn_diagram.diagram_graph.remove_edge(neighbour_node, base_node)
     return neighbour_node

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(fname):
 
 setup(
     name="bpmn_python",
-    version="0.0.19-SNAPSHOT",
+    version="0.0.19",
     author="Izbela Smietana, Krzysztof Honkisz",
     # author_email = "honkiszkrzystof@gmail.com",
     description=("Python library that allows to import/export BPMN diagram (as an XML file) and provides a simple "

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37
+envlist = py37, py310, py312, py313
 
 [testenv]
 deps =


### PR DESCRIPTION
This pull request updates the codebase to ensure compatibility with Python 3.13 and recent versions of all dependencies.

Changes include:
- default setup.py updated to stable 0.0.19 version
- networkx 2.0 function *nodes* compliance
- Pipfile extended by essentail libraries

Tested using **tox** across few fresh version of python:
- Python 3.7
- Python 3.10
- Python 3.12
- Python 3.13
